### PR TITLE
Add/Fix duplicate names and add multi-threaded task support

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,9 +347,11 @@ Here, we notice that we're using the `AnalyticsContext.beginTimedOperation` and 
 
 Note: the full signature of `beginTimedOperation` function is
 ```swift
-AnalyticsContext.beginTimedOperation(operation: String, cancelOnScenePhase: [ScenePhase] = [.background, .inactive])
+AnalyticsContext.beginTimedOperation(operation: String, removeOnDuplicateName: Bool = true, cancelOnScenePhase: [ScenePhase] = [.background, .inactive])
 ```
 By default, operations are told to cancel whenever the user changes apps, closes the app, or puts their phone to sleep (`ScenePhase.background` and `ScenePhase.inactive`). Though, this behavior can be modified to fit a given use case, depending on the operation.
+
+Further, you can specify whether to remove duplicate names or proceed with them. Note that since these are accessible by keypath, ending a timed operation such that duplicate operation names have been started will end **all the operations with that path**, so this is enabled by default in this case.
 
 Under the hood, these two functions create and complete a `AnalyticsTimedOperation` object, whose identifier is `testing.operationview.operation.testing` (that is, `operation.{NAME OF OPERATION}` is appended to the current analytics path).
 
@@ -402,10 +404,12 @@ Our final use case is timed tasks. This is fairly trivial, but has a slight cons
 The library presents a `Task.timedAnalyticsOperation` static function, whose full signature is: 
 
 ```swift
-Task.timedAnalyticsOperation(operation: String, cancelOnScenePhase: [ScenePhase] = [.background, inactive]) {
+Task.timedAnalyticsOperation(operation: String, removeOnDuplicateName: Bool = false, addUniqueIdentifier: Bool = true, cancelOnScenePhase: [ScenePhase] = [.background, inactive]) {
     //function
 }
 ```
+
+Note that this is set up for asynchronous task groups by default. That is: `removeOnDuplicateName` is set to false and `addUniqueIdentifier` is set to true by default. The latter appends a unique string to the end of each task to ensure that the timing of each task can be measured separately.
 
 This is similar to our `AnalyticsContext.beginTimedOperation` function.
 
@@ -428,7 +432,7 @@ func updateIdentity() {
 
 By using `timedAnalyticsOperation`, the library creates an operation, runs the given task, then ends the operation and logs the total running time. This can be valuable in assessing loading times.
 
-The consideration is that because tasks do not take place in the view hierarchy, these operations will be labeled `global.operation.{NAME}`. Duplicate operation names have not been tested.
+The consideration is that because tasks do not take place in the view hierarchy, these operations will be labeled `global.operation.{NAME}`.
 
 ### Analytics Wrap-Up
 

--- a/Sources/Analytics/AnalyticsContext.swift
+++ b/Sources/Analytics/AnalyticsContext.swift
@@ -20,10 +20,10 @@ public struct AnalyticsContext {
         }
     }
     
-    public func beginTimedOperation(operation: String, cancelOnScenePhase: [ScenePhase] = [.background, .inactive]) {
+    public func beginTimedOperation(operation: String, removeOnDuplicateName: Bool = true, cancelOnScenePhase: [ScenePhase] = [.background, .inactive]) {
         guard let analytics = platform?.analytics, operation != "" else { return }
         Task {
-            await analytics.addTimedOperation(AnalyticsTimedOperation(fullKey: "\(key).operation.\(operation)", cancelOnScenePhase: cancelOnScenePhase))
+            await analytics.addTimedOperation(AnalyticsTimedOperation(fullKey: "\(key).operation.\(operation)", cancelOnScenePhase: cancelOnScenePhase), removeDuplicates: removeOnDuplicateName)
         }
     }
     

--- a/Sources/Analytics/AnalyticsTimedOperation.swift
+++ b/Sources/Analytics/AnalyticsTimedOperation.swift
@@ -10,10 +10,10 @@ import SwiftUI
 import Combine
 
 public extension Task where Success == Void, Failure == Never {
-    static func timedAnalyticsOperation(name: String, cancelOnScenePhase: [ScenePhase] = [.background, .inactive], _ operation: @Sendable @escaping () async -> Void) {
+    static func timedAnalyticsOperation(name: String, removeOnDuplicateName: Bool = false, addUniqueIdentifier: Bool = true, cancelOnScenePhase: [ScenePhase] = [.background, .inactive], _ operation: @Sendable @escaping () async -> Void) {
         Task {
-            let analytic = AnalyticsTimedOperation(fullKey: "global.operation.\(name)", cancelOnScenePhase: cancelOnScenePhase)
-            await LabsPlatform.shared?.analytics.addTimedOperation(analytic)
+            let analytic = AnalyticsTimedOperation(fullKey: "global.operation.\(name)\(addUniqueIdentifier ? ".\(UUID().uuidString.prefix(8).lowercased())" : "")", cancelOnScenePhase: cancelOnScenePhase)
+            await LabsPlatform.shared?.analytics.addTimedOperation(analytic, removeDuplicates: removeOnDuplicateName)
             await operation()
             await LabsPlatform.shared?.analytics.completeTimedOperation(analytic)
         }

--- a/Sources/LabsAnalytics.swift
+++ b/Sources/LabsAnalytics.swift
@@ -76,7 +76,10 @@ public extension LabsPlatform {
             await submitQueue()
         }
         
-        func addTimedOperation(_ operation: AnalyticsTimedOperation) {
+        func addTimedOperation(_ operation: AnalyticsTimedOperation, removeDuplicates: Bool) {
+            if removeDuplicates {
+                self.activeOperations.removeAll(where: { $0.fullKey == operation.fullKey })
+            }
             self.activeOperations.append(operation)
         }
         


### PR DESCRIPTION
Duplicate timed operation names need to be considered. This is for a couple reasons:

1. If I start booking a GSR and don't finish it, when I enter the page again, we should cancel the old operation and start a new operation.
2. Tasks run asynchronously, which means that a global operation started may conflict with the same operation, then both will be logged when the first one finished. 

To address the first point, I've added a toggleable control for whether duplicate names should be removed, this is default to true.

To address the second, I've made it so that the Task.timed (whatever it's called), now supports adding a unique identifier so that if they occurred simultaneously (which is often the case with asynchronous tasks), there would be no duplicate operation names.