### PR TITLE
Add Buffering, Configurable Endpoint, and Expensive Geometric Appearance Calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ Analytics are incredibly valuable when making design or roadmap decisions. Given
 
 The library was designed to make logging analytics simple, especially in SwiftUI-based View Hierarchies. However, there are other ways to log analytics that can be done in non SwiftUI-based contexts.
 
+### Configuration
+
+The Analytics configuration is part of the overall LabsPlatform object configuration. This means you can adjust properties such as the endpoint for analytics posts, the interval after which tokens are expired (removed from memory), or the period/interval in which these values are pushed to the endpoint.
+
+Analytics can be disabled by setting a `nil` configuration for the Analytics.Configuration object.
+
 ### SwiftUI Analytics Logging
 
 Given an analytics key: `pennmobile.dining.kcech.breakfast.appear`, it is easy to understand the general structure. Different paths are separated by `.`, enabling an easy understanding of the exact hierarchy that led to the given key.

--- a/Sources/Analytics/AnalyticsContext.swift
+++ b/Sources/Analytics/AnalyticsContext.swift
@@ -32,7 +32,7 @@ public struct AnalyticsContext {
             guard let platform, let oper = await findOperation(key: key, operation: operation) else {
                 return
             }
-            await platform.analytics.completeTimedOperation(oper)
+            await platform.analytics?.completeTimedOperation(oper)
         }
     }
     
@@ -44,7 +44,7 @@ public struct AnalyticsContext {
                 subpath.append(path[j])
             }
             let trialPath = subpath.joined(separator: ".")
-            if let oper = await platform?.analytics.getTimedOperation("\(trialPath).operation.\(operation)") {
+            if let oper = await platform?.analytics?.getTimedOperation("\(trialPath).operation.\(operation)") {
                 return oper
             }
         }

--- a/Sources/Analytics/AnalyticsTimedOperation.swift
+++ b/Sources/Analytics/AnalyticsTimedOperation.swift
@@ -13,9 +13,9 @@ public extension Task where Success == Void, Failure == Never {
     static func timedAnalyticsOperation(name: String, cancelOnScenePhase: [ScenePhase] = [.background, .inactive], _ operation: @Sendable @escaping () async -> Void) {
         Task {
             let analytic = AnalyticsTimedOperation(fullKey: "global.operation.\(name)", cancelOnScenePhase: cancelOnScenePhase)
-            await LabsPlatform.shared?.analytics.addTimedOperation(analytic)
+            await LabsPlatform.shared?.analytics?.addTimedOperation(analytic)
             await operation()
-            await LabsPlatform.shared?.analytics.completeTimedOperation(analytic)
+            await LabsPlatform.shared?.analytics?.completeTimedOperation(analytic)
         }
     }
 }

--- a/Sources/Auth/LabsPlatformAuth.swift
+++ b/Sources/Auth/LabsPlatformAuth.swift
@@ -82,7 +82,7 @@ extension LabsPlatform {
         let verifier: String = AuthUtilities.codeVerifier()
         let state: String = AuthUtilities.stateString()
         guard let url = URL(string:
-                                "\(LabsPlatform.authEndpoint.absoluteString)?response_type=code&code_challenge=\(AuthUtilities.codeChallenge(from: verifier))&code_challenge_method=S256&client_id=\(self.clientId)&redirect_uri=\(self.authRedirect)&scope=openid%20read%20introspection&state=\(state)") else { throw PlatformAuthError.invalidUrl }
+                                "\(configuration.authEndpoint.absoluteString)?response_type=code&code_challenge=\(AuthUtilities.codeChallenge(from: verifier))&code_challenge_method=S256&client_id=\(self.clientId)&redirect_uri=\(self.authRedirect)&scope=openid%20read%20introspection&state=\(state)") else { throw PlatformAuthError.invalidUrl }
         return .newLogin(url: url, state: state, verifier: verifier)
     }
     
@@ -241,7 +241,7 @@ extension LabsPlatform {
         
         let postData =  postString.data(using: .utf8)
 
-        var request = URLRequest(url: LabsPlatform.tokenEndpoint)
+        var request = URLRequest(url: configuration.tokenEndpoint)
         request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "POST"
         request.httpBody = postData
@@ -271,7 +271,7 @@ extension LabsPlatform {
         
         let postData =  postString.data(using: .utf8)
         
-        var request = URLRequest(url: LabsPlatform.tokenEndpoint)
+        var request = URLRequest(url: configuration.tokenEndpoint)
         request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "POST"
         request.httpBody = postData

--- a/Sources/Auth/LabsPlatformAuth.swift
+++ b/Sources/Auth/LabsPlatformAuth.swift
@@ -291,7 +291,20 @@ extension LabsPlatform {
             return .failure(DecodingError.valueNotFound(PlatformAuthCredentials.self, DecodingError.Context(codingPath: [], debugDescription: "Could not decode credentials")))
         }
         
-        return .success(data)
+        if let idToken = data.idToken {
+            return .success(data)
+        } else {
+            // specifically retain the ID token from initial auth (if available)
+            
+            let combinedToken = PlatformAuthCredentials(
+                accessToken: data.accessToken,
+                expiresIn: data.expiresIn,
+                tokenType: data.tokenType,
+                refreshToken: data.refreshToken,
+                idToken: auth.idToken,
+                issuedAt: data.issuedAt)
+            return .success(combinedToken)
+        }
     }
 }
 

--- a/Sources/LabsPlatform.swift
+++ b/Sources/LabsPlatform.swift
@@ -209,6 +209,7 @@ public extension View {
     /// - Parameters:
     ///     - clientId: A Platform-granted clientId that has permission to get JWTs
     ///     - redirectUrl: A valid redirect URI (allowed by the Platform application)
+    ///     - configuration: An overridden configuration object (for when specific behavior modification is desired)
     ///     - defaultLoginHandler: A function that should be called when the login flow intercepts the default login credentials (user and password both "root", by default)
     ///     - loginHandler(loggedIn: Bool): a function that will be called whenever the Platform goes to either the logged-in state or the logged-out state. This includes
     ///             uses of the [`LabsPlatform.logoutPlatform()`](x-source-tag://logoutPlatform) function (will always be `false`)


### PR DESCRIPTION
**Expensive Geometric Appearance Calculation**
For Portal-related appearance calculation, using `onAppear` and `onDisappear` is actually not accurate enough. An option has been added to support a more expensive (computationally) method of calculating when a view enters the screen (by literally measuring when it crosses the viewport)

**Buffering**
Due to this more expensive appearance calculation, we now have to consider that a person spam scrolling on their screen might trigger the appearance methods very frequently. We now have added a 5-second buffer (which can be modified) to ensure that a single token can not be recorded more than once every 5 seconds.

**Configurable Endpoint**
The endpoint to which Analytics values are sent can now be fully modified to support local testing. I was using a personal project, where I was sending values to `0.0.0.0:80` using a local server, and it works great! Using the docker-compose environment for analytics allowed me to also see values hitting the redis cache in real time.