### PR TITLE
Enforce a lock when refreshing

### DIFF
--- a/Sources/LabsPlatform.swift
+++ b/Sources/LabsPlatform.swift
@@ -34,7 +34,10 @@ public final class LabsPlatform: ObservableObject {
         self.authRedirect = redirectUrl
         self.analytics = Analytics()
         self.authState = getCurrentAuthState()
-        LabsPlatform.shared = self
+        Task {
+            self.authState = await getRefreshedAuthState()
+            LabsPlatform.shared = self
+        }
         UserDefaults.standard.loadPlatformHTTPCookies()
     }
     

--- a/Sources/LabsPlatform.swift
+++ b/Sources/LabsPlatform.swift
@@ -27,6 +27,7 @@ public final class LabsPlatform: ObservableObject {
     let clientId: String
     let authRedirect: String
     var webViewCheckedContinuation: CheckedContinuation<PlatformAuthState, any Error>?
+    var enforceRefreshContinuationQueue: [CheckedContinuation<Void, Never>]? = nil
     
     
     public init(clientId: String, redirectUrl: String) {
@@ -34,10 +35,7 @@ public final class LabsPlatform: ObservableObject {
         self.authRedirect = redirectUrl
         self.analytics = Analytics()
         self.authState = getCurrentAuthState()
-        Task {
-            self.authState = await getRefreshedAuthState()
-            LabsPlatform.shared = self
-        }
+        LabsPlatform.shared = self
         UserDefaults.standard.loadPlatformHTTPCookies()
     }
     


### PR DESCRIPTION
There was the case where multiple competing refresh operations were scheduled, resulting in platform rejecting the refresh token (which had already been used).

This PR enforces a "lock" on token-related operations (such as generating a new access token URLRequest) until we finish the single refresh operation.

This is related to https://github.com/pennlabs/penn-mobile-ios/pull/641, where the data race described in the comments is resolved here.